### PR TITLE
fix(grafana): stop stripping Content-Encoding on gzipped assets

### DIFF
--- a/apps/grafana/overlay/korriban/istio-routing.yaml
+++ b/apps/grafana/overlay/korriban/istio-routing.yaml
@@ -26,9 +26,6 @@ spec:
           set:
             X-Forwarded-Proto: "https"
             X-Forwarded-Host: "grafana.home.cwbtech.net"
-        response:
-          remove:
-            - "content-encoding" # Prevent double compression
     # Handle all other requests
     - match:
         - uri:


### PR DESCRIPTION
## Summary
- The `monitoring/grafana` Istio VirtualService removed the `Content-Encoding` header from gzipped JS/CSS assets ("prevent double compression"). Browsers requesting `Accept-Encoding: gzip` then received gzip bytes labeled `text/javascript` with no decode signal → frontend never booted → "Grafana has failed to load its application files."
- Removes the `response.remove: [content-encoding]` directive so the header passes through and browsers decode assets correctly.

## Evidence
Asset fetched with `Accept-Encoding: gzip` returned `200`, `content-type: text/javascript`, **no** `content-encoding`, body = raw gzip (`1f 8b 08`). Plain curl (no Accept-Encoding) returned valid uncompressed JS, which masked the bug. Exposed by the bump to `grafana/grafana:13.0.1`.

## Verification
- `kubectl kustomize apps/grafana/overlay/korriban` renders a valid VirtualService with the directive gone.
- Post-merge: Flux reconciles; load Grafana in a clean browser — assets return `content-encoding: gzip` and the UI boots.

Closes BOW-293