### PR TITLE
feat(databases): add CloudNativePG operator and databases namespace

### DIFF
--- a/apps/databases/base/kustomization.yaml
+++ b/apps/databases/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/apps/databases/base/namespace.yaml
+++ b/apps/databases/base/namespace.yaml
@@ -5,9 +5,5 @@ metadata:
   labels:
     name: databases
     app.kubernetes.io/name: databases
-    # Istio sidecar injection disabled: the CNPG Postgres wire protocol and
-    # streaming replication do not tolerate Istio mTLS interception well, and
-    # all consumers reach the DB via plain cluster DNS. (n8n takes the
-    # equivalent step at the workload level via its disable-istio-database
-    # patch rather than at the namespace.)
+    # Postgres wire protocol doesn't tolerate Istio mTLS; consumers use cluster DNS
     istio-injection: disabled

--- a/apps/databases/base/namespace.yaml
+++ b/apps/databases/base/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: databases
+  labels:
+    name: databases
+    app.kubernetes.io/name: databases
+    # Istio sidecar injection disabled: the CNPG Postgres wire protocol and
+    # streaming replication do not tolerate Istio mTLS interception well, and
+    # all consumers reach the DB via plain cluster DNS. (n8n takes the
+    # equivalent step at the workload level via its disable-istio-database
+    # patch rather than at the namespace.)
+    istio-injection: disabled

--- a/clusters/korriban/apps/databases/kustomization.yaml
+++ b/clusters/korriban/apps/databases/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../apps/databases/base

--- a/clusters/korriban/apps/kustomization.yaml
+++ b/clusters/korriban/apps/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - immich
   - oncall
   - semaphore
+  - databases

--- a/clusters/korriban/flux-system/kustomization-apps.yaml
+++ b/clusters/korriban/flux-system/kustomization-apps.yaml
@@ -6,8 +6,7 @@ metadata:
 spec:
   dependsOn:
     - name: infrastructure
-    # Ensures the CloudNativePG operator + CRDs exist before any app applies
-    # (Phase 2 adds CNPG Cluster resources under the databases app).
+    # CNPG operator/CRDs before Phase 2 Cluster CRs
     - name: cloudnative-pg-base
   interval: 10m
   sourceRef:

--- a/clusters/korriban/flux-system/kustomization-apps.yaml
+++ b/clusters/korriban/flux-system/kustomization-apps.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   dependsOn:
     - name: infrastructure
+    # Ensures the CloudNativePG operator + CRDs exist before any app applies
+    # (Phase 2 adds CNPG Cluster resources under the databases app).
+    - name: cloudnative-pg-base
   interval: 10m
   sourceRef:
     kind: GitRepository

--- a/clusters/korriban/infrastructure/cloudnative-pg-base.yaml
+++ b/clusters/korriban/infrastructure/cloudnative-pg-base.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg-base
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./infrastructure/cloudnative-pg/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  timeout: 5m
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: cloudnative-pg
+      namespace: flux-system

--- a/clusters/korriban/kustomization.yaml
+++ b/clusters/korriban/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - infrastructure/istio-base.yaml
   - infrastructure/istio-config.yaml
   - infrastructure/prometheus-operator-crds-kustomization.yaml
+  - infrastructure/cloudnative-pg-base.yaml

--- a/infrastructure/cloudnative-pg/base/helmrelease.yaml
+++ b/infrastructure/cloudnative-pg/base/helmrelease.yaml
@@ -1,0 +1,46 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+  namespace: flux-system
+spec:
+  interval: 30m
+  targetNamespace: cnpg-system
+  chart:
+    spec:
+      chart: cloudnative-pg
+      version: "0.28.2"
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: flux-system
+      interval: 12h
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # CNPG ships its CRDs in the chart's templates/crds (annotated
+    # helm.sh/resource-policy: keep), installed via this value — NOT via Flux's
+    # install/upgrade `crds:` policy, which only governs a top-level crds/ dir
+    # this chart doesn't use. Consequence: CRDs install on first deploy but are
+    # NOT auto-upgraded; a major CNPG bump may need a manual CRD apply.
+    crds:
+      create: true
+    # Single operator replica is plenty for this homelab; the operator is not
+    # in the data path — Postgres availability comes from the Cluster replicas.
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    monitoring:
+      # PodMonitor for the operator; per-Cluster PodMonitors are enabled on the
+      # Cluster resources themselves in later phases.
+      podMonitorEnabled: false

--- a/infrastructure/cloudnative-pg/base/helmrelease.yaml
+++ b/infrastructure/cloudnative-pg/base/helmrelease.yaml
@@ -23,15 +23,9 @@ spec:
     remediation:
       retries: 3
   values:
-    # CNPG ships its CRDs in the chart's templates/crds (annotated
-    # helm.sh/resource-policy: keep), installed via this value — NOT via Flux's
-    # install/upgrade `crds:` policy, which only governs a top-level crds/ dir
-    # this chart doesn't use. Consequence: CRDs install on first deploy but are
-    # NOT auto-upgraded; a major CNPG bump may need a manual CRD apply.
+    # Chart-managed CRDs (templates/crds, resource-policy: keep); not auto-upgraded on bump.
     crds:
       create: true
-    # Single operator replica is plenty for this homelab; the operator is not
-    # in the data path — Postgres availability comes from the Cluster replicas.
     replicaCount: 1
     resources:
       requests:
@@ -41,6 +35,5 @@ spec:
         cpu: 200m
         memory: 256Mi
     monitoring:
-      # PodMonitor for the operator; per-Cluster PodMonitors are enabled on the
-      # Cluster resources themselves in later phases.
+      # per-Cluster PodMonitors come in later phases
       podMonitorEnabled: false

--- a/infrastructure/cloudnative-pg/base/helmrepository.yaml
+++ b/infrastructure/cloudnative-pg/base/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  url: https://cloudnative-pg.github.io/charts
+  type: default

--- a/infrastructure/cloudnative-pg/base/kustomization.yaml
+++ b/infrastructure/cloudnative-pg/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary
Phase 1 foundations for migrating PostgreSQL off the standalone VM (`10.10.7.200`) into the cluster (BOW-310).

- **CloudNativePG operator** — HelmRelease (`infrastructure/cloudnative-pg/base/`, chart `cloudnative-pg` 0.28.2 → operator 1.29.1, `targetNamespace: cnpg-system`), wired via the Flux Kustomization CR `clusters/korriban/infrastructure/cloudnative-pg-base.yaml` (health-checked, `wait: true`) and registered in `clusters/korriban/kustomization.yaml` — same pattern as `cert-manager-base`.
- **`databases` namespace** (`apps/databases/base/`) with `istio-injection: disabled` (Postgres wire protocol / streaming replication don't tolerate mTLS sidecar interception; all consumers use plain cluster DNS).
- **Ordering** — the `apps` Flux Kustomization now `dependsOn: cloudnative-pg-base` so Phase 2's CNPG `Cluster` CRs can't race the operator CRDs.
- CRD lifecycle made explicit via `crds.create: true` (the chart keeps CRDs under `templates/crds`; documented that major bumps need a manual CRD apply).

**MinIO was intentionally dropped** from this phase: MinIO doesn't support an NFS data backend and iSCSI is ruled out, so backups will instead be a scheduled `pg_dump`/`pg_basebackup` CronJob to `nfs-holocron-backup` (built in Phase 2/6).

Deferred to Phase 2 (noted by review, not blocking): add an `overlay/korriban` layer + `commonAnnotations` for the `databases` app when the CNPG `Cluster` lands.

## Test plan
- [ ] Flux reconciles `cloudnative-pg-base`; `kubectl get crd | grep postgresql` shows the CNPG CRDs
- [ ] CNPG operator pod Running in `cnpg-system`
- [ ] `databases` namespace exists with `istio-injection=disabled`
- [ ] `kubectl get kustomization -n flux-system apps` shows it waiting on `cloudnative-pg-base` then Ready

BOW-310