### PR TITLE
fix(databases): move apps-postgres to a no_root_squash NFS export

### DIFF
--- a/apps/databases/overlay/korriban/apps-postgres-cluster.yaml
+++ b/apps/databases/overlay/korriban/apps-postgres-cluster.yaml
@@ -14,7 +14,7 @@ spec:
   enableSuperuserAccess: true
 
   storage:
-    storageClass: nfs-holocron-general
+    storageClass: nfs-holocron-databases
     size: 8Gi
 
   resources:

--- a/apps/databases/overlay/korriban/backup-cronjob.yaml
+++ b/apps/databases/overlay/korriban/backup-cronjob.yaml
@@ -42,12 +42,9 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
-                  # Fail loudly if the NFS volume isn't writable by this uid, rather
-                  # than silently producing no backups (this is the first consumer of
-                  # nfs-holocron-backup, so the export's squash mapping is unproven).
                   probe="/backups/.write-probe-$$"
                   if ! touch "${probe}" 2>/dev/null; then
-                    echo "FATAL: /backups not writable by uid $(id -u) — check nfs-holocron-backup export squash" >&2
+                    echo "FATAL: /backups not writable by uid $(id -u) — check nfs-holocron-databases export squash" >&2
                     exit 1
                   fi
                   rm -f "${probe}"

--- a/apps/databases/overlay/korriban/backup-pvc.yaml
+++ b/apps/databases/overlay/korriban/backup-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: nfs-holocron-backup
+  storageClassName: nfs-holocron-databases
   resources:
     requests:
       storage: 10Gi

--- a/clusters/korriban/infrastructure/storage/nfs-csi/storage-classes.yaml
+++ b/clusters/korriban/infrastructure/storage/nfs-csi/storage-classes.yaml
@@ -43,6 +43,27 @@ allowVolumeExpansion: true
 reclaimPolicy: Retain
 
 ---
+# Database Storage - dedicated no_root_squash export for CNPG (PGDATA uid 26)
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-holocron-databases
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: holocron.home.cwbtech.net
+  share: /volume1/k8s-postgres
+mountOptions:
+  - hard
+  - nfsvers=4.1
+  - rsize=131072
+  - wsize=131072
+  - timeo=600
+  - retrans=2
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+
+---
 # Backup Storage
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
## Summary

Hotfix for Phase 2 (**BOW-310**). The live import from #292 failed with `initdb` FATAL `data directory "/var/lib/postgresql/data/pgdata" has wrong ownership` — CNPG runs postgres as uid 26 and `initdb` requires PGDATA owned by 26, but the shared `nfs-holocron-general` export (`/volume1/kubernetes`) root-squashes, so the kubelet `fsGroup` chown is denied and the dir stays owned by the anon uid.

- New **`nfs-holocron-databases`** StorageClass → `holocron:/volume1/k8s-postgres` (a dedicated `no_root_squash` export), Retain.
- Repoint the `apps-postgres` Cluster data volume + backup PVC to it.
- Shared `/volume1/kubernetes` export is untouched (loki/prometheus/oncall/etc. unaffected).

## Pre-PR review (4 reviewers)

- Fixed: stale `nfs-holocron-backup` reference in the backup CronJob probe string.
- **Deploy step (not a manifest change):** PVC/CNPG storage is immutable — after merge the existing failed `apps-postgres` cluster and the `apps-postgres-backups` PVC must be deleted so they re-provision on the new class (both empty: failed bootstrap / backup never ran).
- Accepted tradeoff: backups co-located on the same export as data. Same physical Synology `volume1` as the old backup share, separate PVC + Retain preserves logical isolation. Can split to a dedicated `no_root_squash` backup export later.

## NAS follow-up (your side)
- Tighten the `/volume1/k8s-postgres` export's allowed-client list to the K8s node IPs (10.10.7.10/.22/.65) rather than the whole subnet.

## Test plan
- [ ] Merge → infra reconciles (StorageClass created) → delete failed cluster + backup PVC → CNPG re-provisions on `nfs-holocron-databases`
- [ ] `initdb` succeeds (no ownership FATAL); cluster reaches Ready
- [ ] Quiesce consumers → import completes → 11 DBs + 4 roles present
- [ ] Backup CronJob writes a `*.sql.gz` to the new export

BOW-310