### PR TITLE
feat(databases): cut n8n, oncall, semaphore over to in-cluster apps-postgres

### DIFF
--- a/apps/n8n/base/n8n-deployment.yaml
+++ b/apps/n8n/base/n8n-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: DB_TYPE
               value: postgresdb
             - name: DB_POSTGRESDB_HOST
-              value: 10.10.7.200
+              value: apps-postgres-rw.databases.svc.cluster.local
             - name: DB_POSTGRESDB_PORT
               value: "5432"
             - name: DB_POSTGRESDB_DATABASE

--- a/apps/n8n/base/n8n-worker-deployment.yaml
+++ b/apps/n8n/base/n8n-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: DB_TYPE
               value: postgresdb
             - name: DB_POSTGRESDB_HOST
-              value: 10.10.7.200
+              value: apps-postgres-rw.databases.svc.cluster.local
             - name: DB_POSTGRESDB_PORT
               value: "5432"
             - name: DB_POSTGRESDB_DATABASE

--- a/apps/oncall/base/helmrelease.yaml
+++ b/apps/oncall/base/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
 
     # External PostgreSQL connection
     externalPostgresql:
-      host: postgres.home.cwbtech.net
+      host: apps-postgres-rw.databases.svc.cluster.local
       port: 5432
       db: oncall
       user: oncall

--- a/apps/semaphore/base/deployment.yaml
+++ b/apps/semaphore/base/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: SEMAPHORE_DB_DIALECT
               value: postgres
             - name: SEMAPHORE_DB_HOST
-              value: 10.10.7.200
+              value: apps-postgres-rw.databases.svc.cluster.local
             - name: SEMAPHORE_DB_PORT
               value: "5432"
             - name: SEMAPHORE_DB_NAME


### PR DESCRIPTION
## Summary
Phase 4 cutover (**BOW-310**). Repoint n8n (deploy + worker), oncall, and semaphore postgres host from the VM to the in-cluster service `apps-postgres-rw.databases.svc.cluster.local`. No secret changes — imported roles kept their passwords, so existing secrets authenticate.

Coordinated cutover with kubernetes-private (arr). Merge as part of the quiesce + clean re-import window.

BOW-310