### PR TITLE
fix(databases): restricted-PodSecurity backup job; drop VM IP from MetalLB pool

### DIFF
--- a/apps/databases/overlay/korriban/backup-cronjob.yaml
+++ b/apps/databases/overlay/korriban/backup-cronjob.yaml
@@ -20,11 +20,17 @@ spec:
             runAsUser: 26
             runAsGroup: 26
             fsGroup: 26
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: pgdump
-              # Same image as the cluster so pg_dumpall matches the server version.
               image: ghcr.io/cloudnative-pg/postgresql:16.14
               imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               env:
                 - name: PGHOST
                   value: apps-postgres-rw

--- a/clusters/korriban/infrastructure/metallb/config.yaml
+++ b/clusters/korriban/infrastructure/metallb/config.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-    - 10.10.7.200-10.10.7.250
+    - 10.10.7.201-10.10.7.250
   autoAssign: true
   avoidBuggyIPs: true
 ---


### PR DESCRIPTION
## Summary
BOW-310 follow-ups:
- **Backup CronJob** now satisfies restricted PodSecurity (`seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`). Was warn-only before; this makes it clean and future-proofs against enforcement.
- **MetalLB** default pool `10.10.7.200-.250` → `.201-.250` so the postgres VM IP `10.10.7.200` can't be auto-assigned to a LoadBalancer again (it had collided with `qbittorrent-torrent`).

Paired with kubernetes-private (qbittorrent pinned to `.201`).

## Test plan
- [ ] Merge + reconcile; re-trigger `apps-postgres-backup` job → dump still written under restricted securityContext
- [ ] MetalLB reassigns qbittorrent off `.200`; VM `.200` no longer in pool

BOW-310