### PR TITLE
feat(databases): provision immich-postgres CNPG cluster with VectorChord

### DIFF
--- a/apps/databases/overlay/korriban/immich-backup-cronjob.yaml
+++ b/apps/databases/overlay/korriban/immich-backup-cronjob.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: immich-postgres-backup
+  namespace: databases
+spec:
+  schedule: "0 3 * * *"
+  timeZone: America/Denver
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 26
+            runAsGroup: 26
+            fsGroup: 26
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: pgdump
+              image: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                - name: PGHOST
+                  value: immich-postgres-rw
+                - name: PGUSER
+                  value: postgres
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-postgres-superuser
+                      key: password
+                - name: RETENTION_DAYS
+                  value: "14"
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  probe="/backups/.write-probe-$$"
+                  if ! touch "${probe}" 2>/dev/null; then
+                    echo "FATAL: /backups not writable by uid $(id -u) — check nfs-holocron-databases export squash" >&2
+                    exit 1
+                  fi
+                  rm -f "${probe}"
+
+                  ts=$(date +%Y%m%d-%H%M%S)
+                  out="/backups/immich-postgres-${ts}.sql.gz"
+                  tmp="${out}.tmp"
+                  trap 'rm -f "${tmp}"' EXIT
+                  echo "Dumping all databases from ${PGHOST} to ${out}"
+                  pg_dumpall --clean --if-exists | gzip > "${tmp}"
+                  gzip -t "${tmp}"
+                  mv "${tmp}" "${out}"
+                  trap - EXIT
+                  echo "Backup complete: $(du -h "${out}" | cut -f1)"
+                  echo "Pruning dumps older than ${RETENTION_DAYS} days"
+                  find /backups -maxdepth 1 -name 'immich-postgres-*.sql.gz' -mtime "+${RETENTION_DAYS}" -print -delete
+                  echo "Current backups:"
+                  ls -lh /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: immich-postgres-backups

--- a/apps/databases/overlay/korriban/immich-backup-pvc.yaml
+++ b/apps/databases/overlay/korriban/immich-backup-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-postgres-backups
+  namespace: databases
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-holocron-databases
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/databases/overlay/korriban/immich-postgres-cluster.yaml
+++ b/apps/databases/overlay/korriban/immich-postgres-cluster.yaml
@@ -1,0 +1,49 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-postgres
+  namespace: databases
+spec:
+  instances: 2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3
+  primaryUpdateStrategy: unsupervised
+  enableSuperuserAccess: true
+
+  postgresql:
+    shared_preload_libraries:
+      - vchord.so
+
+  storage:
+    storageClass: nfs-holocron-databases
+    size: 10Gi
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+  bootstrap:
+    initdb:
+      database: immich
+      owner: immich
+      import:
+        type: microservice
+        databases:
+          - immich
+        source:
+          externalCluster: vm-postgres
+        postImportApplicationSQL:
+          - CREATE EXTENSION IF NOT EXISTS vchord CASCADE
+
+  externalClusters:
+    - name: vm-postgres
+      connectionParameters:
+        host: "10.10.7.200"
+        user: postgres
+        dbname: postgres
+        sslmode: require
+      password:
+        name: apps-postgres-vm-source
+        key: password

--- a/apps/databases/overlay/korriban/immich-postgres-cluster.yaml
+++ b/apps/databases/overlay/korriban/immich-postgres-cluster.yaml
@@ -15,7 +15,7 @@ spec:
 
   storage:
     storageClass: nfs-holocron-databases
-    size: 10Gi
+    size: 15Gi
 
   resources:
     requests:

--- a/apps/databases/overlay/korriban/kustomization.yaml
+++ b/apps/databases/overlay/korriban/kustomization.yaml
@@ -7,5 +7,8 @@ resources:
   - vm-source-sealed-secret.yaml
   - backup-pvc.yaml
   - backup-cronjob.yaml
+  - immich-postgres-cluster.yaml
+  - immich-backup-pvc.yaml
+  - immich-backup-cronjob.yaml
 commonAnnotations:
   app.kubernetes.io/instance: korriban


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the immich cutover window — merging triggers the one-shot import

Phase 3 of BOW-310. Provisions `immich-postgres` (CNPG, VectorChord) and imports the immich DB from the VM. Because `bootstrap.initdb.import` runs once at cluster creation, immich must be **quiesced first** (or we re-import clean at cutover), exactly like apps-postgres.

## What it builds
- `immich-postgres` CNPG Cluster (2 instances) on `ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3` (PG16 + pgvector + VectorChord), `shared_preload_libraries: [vchord.so]`, storage `nfs-holocron-databases` 15Gi.
- **microservice** `bootstrap.initdb.import` of the immich DB (owner `immich`) from the VM, then `postImportApplicationSQL: CREATE EXTENSION vchord CASCADE`. (immich v2.4.1 needs pgvector ≥0.7 / VectorChord; VM is on pgvector 0.6.0.)
- immich backup CronJob (`pg_dumpall` → `nfs-holocron-databases`, 03:00, restricted PodSecurity).
- Reuses the existing `apps-postgres-vm-source` sealed secret.

## Pre-PR review (4 reviewers) — findings & resolution
- **PG 16.9 target vs 16.14 source:** acceptable — same major (16), so `pg_dump` 16.9 dumps a 16.14 server fine (abort is only on newer *major*). 16.9 is the highest VectorChord PG16 tag available.
- **Storage:** bumped 10Gi → 15Gi for vchord HNSW indexes (matches plan).
- **microservice import drops roles → immich role gets a fresh CNPG-managed password.** ❗ **Phase 5 cutover must reseal `immich-secrets`** (immich ns) to the `immich-postgres-app` password, or immich won't authenticate. Tracked for Phase 5.
- `shared_preload_libraries: vchord.so` verified correct per VectorChord/immich-charts docs.
- Backups land on `nfs-holocron-databases` (not `nfs-holocron-backup`) — consistent with the Phase 2 no_root_squash decision; vault docs to be updated.

## Phase 5 (separate window, the risky part)
Quiesce immich → final import → reseal immich-secrets → repoint `apps/immich/base/configmap.yaml` DB_HOSTNAME → reindex vectors → verify smart search + face recognition.

BOW-310