### PR TITLE
feat: alert on cert-manager certs stuck renewing or expiring soon

### DIFF
--- a/apps/alertmanager/base/prometheus-rules.yaml
+++ b/apps/alertmanager/base/prometheus-rules.yaml
@@ -171,3 +171,23 @@ spec:
           annotations:
             summary: "FluxCD resource {{ $labels.kind }}/{{ $labels.name }} is suspended"
             description: "FluxCD {{ $labels.kind }}/{{ $labels.name }} in namespace {{ $labels.namespace }} is suspended."
+    - name: certmanager.rules
+      rules:
+        # Certificate stuck renewing — scheduled renewal overdue >7d (silent until expiry)
+        - alert: CertManagerCertStuckRenewing
+          expr: (time() - certmanager_certificate_renewal_timestamp_seconds) > (7 * 24 * 3600)
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "cert {{ $labels.namespace }}/{{ $labels.name }} stuck renewing >7d"
+            description: "Scheduled renewal for {{ $labels.namespace }}/{{ $labels.name }} (issuer {{ $labels.issuer_name }}) has been overdue more than 7 days — ACME/DNS-01 is likely failing. Check: kubectl describe challenge -n {{ $labels.namespace }}"
+        # Backstop — certificate expires within 7d regardless of cause
+        - alert: CertManagerCertExpiringSoon
+          expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < (7 * 24 * 3600)
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "cert {{ $labels.namespace }}/{{ $labels.name }} expires in <7d"
+            description: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires soon and has not renewed."


### PR DESCRIPTION
## Summary
Adds a `certmanager.rules` group to the Prometheus alerting rules so a stuck certificate renewal can't go silent again (as the `*.home.cwbtech.net` wildcard did for 31 days).

## Alerts
- **CertManagerCertStuckRenewing** (`critical`) — `(time() - certmanager_certificate_renewal_timestamp_seconds) > 7d`. Fires when cert-manager's scheduled renewal is overdue by more than 7 days, i.e. the renewal timestamp stops advancing because ACME/DNS-01 is failing. This is the exact failure mode from the recent incident — it would have fired ~3 weeks before expiry.
- **CertManagerCertExpiringSoon** (`critical`) — `(certmanager_certificate_expiration_timestamp_seconds - time()) < 7d`. Backstop that fires regardless of cause (covers the case where the renewal metric is missing entirely).

`for: 1h` on both filters scrape blips; the 7-day window lives in the threshold.

## Validation
- cert-manager metrics confirmed present in Prometheus (scraped via the `kubernetes-pods` annotation job — no new ServiceMonitor needed).
- Both PromQL expressions evaluated against live Prometheus: parse cleanly, return empty while healthy (renewal 60d out, expiry 90d out), so no false positives.
- `kubectl kustomize apps/alertmanager/base` builds clean.

## Routing
Uses the existing `severity: critical` label, routed by the current Alertmanager config — no routing changes needed.