### PR TITLE
fix(sealed-secrets): repoint HelmRepository to bitnami.github.io

### DIFF
--- a/clusters/korriban/infrastructure/sealed-secrets/release.yaml
+++ b/clusters/korriban/infrastructure/sealed-secrets/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://bitnami-labs.github.io/sealed-secrets
+  url: https://bitnami.github.io/sealed-secrets
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
## Problem
`HelmRepository/sealed-secrets-controller` points at `https://bitnami-labs.github.io/sealed-secrets`, which now 404s (the whole GitHub Pages site is gone — the project moved from the `bitnami-labs` org to `bitnami`).

This fails the `infrastructure` Kustomization health check, which **cascades**: `apps` and `media-apps` both declare `dependsOn: infrastructure`, so they've been stuck at `READY=False` — none of the recently merged app updates (e.g. Renovate's sonarr 4.0.18/4.0.19 bumps) have been applied. The cluster is running sonarr `4.0.17` while git is at `4.0.19`.

## Fix
Repoint the HelmRepository URL: `bitnami-labs.github.io` → `bitnami.github.io`.

Verified live: `https://bitnami.github.io/sealed-secrets/index.yaml` → 200, serving chart `2.19.1` (appVersion `0.38.4`, published 2026-07-03). The existing `version: ">=2.0.0"` constraint still resolves. Only functional reference in the repo (grep-confirmed).

## After merge
Flux reconciles `infrastructure` → unblocks `apps` + `media-apps` → the whole media stack catches up to git in one pass.