### PR TITLE
feat(immich): bring immich under Renovate management

### DIFF
--- a/apps/immich/base/immich-ml-deployment.yaml
+++ b/apps/immich/base/immich-ml-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         nvidia.com/gpu: "true"
       containers:
         - name: immich-ml
-          image: ghcr.io/immich-app/immich-machine-learning
+          image: ghcr.io/immich-app/immich-machine-learning:v2.4.1-cuda
           ports:
             - containerPort: 3003
           env:

--- a/apps/immich/base/immich-server-deployment.yaml
+++ b/apps/immich/base/immich-server-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         nvidia.com/gpu: "true"
       containers:
         - name: immich-server
-          image: ghcr.io/immich-app/immich-server
+          image: ghcr.io/immich-app/immich-server:v2.4.1
           ports:
             - containerPort: 2283
           envFrom:

--- a/apps/immich/base/kustomization.yaml
+++ b/apps/immich/base/kustomization.yaml
@@ -9,10 +9,3 @@ resources:
 commonLabels:
   app.kubernetes.io/name: immich
   app.kubernetes.io/part-of: photo-management
-images:
-  - name: ghcr.io/immich-app/immich-server
-    newTag: v2.4.1
-  - name: ghcr.io/immich-app/immich-machine-learning
-    newTag: v2.4.1-cuda
-  - name: redis
-    newTag: 7-alpine

--- a/apps/immich/base/redis-deployment.yaml
+++ b/apps/immich/base/redis-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis
+          image: redis:7-alpine
           args: ["--save", ""]
           ports:
             - containerPort: 6379

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,18 @@
   "commitMessageAction": "update",
   "kubernetes": {
     "managerFilePatterns": ["apps/.+\\.yaml$", "infrastructure/.+\\.yaml$"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "ghcr.io/immich-app/immich-server",
+        "ghcr.io/immich-app/immich-machine-learning"
+      ],
+      "groupName": "immich"
+    },
+    {
+      "matchPackageNames": ["ghcr.io/immich-app/immich-machine-learning"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-cuda$"
+    }
+  ]
 }


### PR DESCRIPTION
Closes BOW-382, closes BOW-383.

## Problem
immich runs in korriban but Renovate has **never** bumped it — every immich change in git history is a manual feat/fix. The Deployment `image:` lines were untagged and the versions lived in a kustomize `images: newTag:` block that Renovate's kubernetes manager doesn't read.

## Fix
**BOW-382 — inline tags** (matches every working app, e.g. radarr/sonarr):
- `immich-server-deployment.yaml` → `:v2.4.1`
- `immich-ml-deployment.yaml` → `:v2.4.1-cuda`
- `redis-deployment.yaml` → `:7-alpine`
- removed the `images:` newTag block from `base/kustomization.yaml`

**BOW-383 — renovate.json packageRules**:
- group `immich-server` + `immich-machine-learning` → they bump **in lockstep** (one PR, never drift apart)
- regex versioning for the ML image so it tracks `vX.Y.Z-**cuda**` tags in semver order (default docker versioning can't)

## Verification
- `kustomize build apps/immich/overlay/korriban` renders **byte-identical images** to before → **no cluster change, zero pods roll on merge**. Pure manifest-structure change for Renovate's benefit.
- `renovate.json` is valid JSON.
- regex confirmed: matches `v2.4.1-cuda` / `v2.5.0-cuda`, rejects plain `v2.4.1` and `v2.4.1-openvino`.

## After merge
Renovate's next scan detects the now-inline, versioned immich images and (if v2.4.1 is behind latest) opens a single grouped "immich" update PR — closing the coverage gap where immich was silently drifting outside automated updates.