### PR TITLE
feat(gpu-plugins): bring intel + nvidia device plugins under Renovate

### DIFF
--- a/infrastructure/intel-gpu-plugin/base/daemonset.yaml
+++ b/infrastructure/intel-gpu-plugin/base/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         intel.com/gpu: "true"
       containers:
         - name: intel-gpu-plugin
-          image: intel/intel-gpu-plugin
+          image: intel/intel-gpu-plugin:0.31.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME

--- a/infrastructure/intel-gpu-plugin/base/kustomization.yaml
+++ b/infrastructure/intel-gpu-plugin/base/kustomization.yaml
@@ -6,7 +6,3 @@ resources:
 commonLabels:
   app.kubernetes.io/name: intel-gpu-plugin
   app.kubernetes.io/part-of: gpu-infrastructure
-images:
-  - name: intel/intel-gpu-plugin
-    newName: intel/intel-gpu-plugin
-    newTag: "0.31.0"

--- a/infrastructure/nvidia-device-plugin/base/daemonset.yaml
+++ b/infrastructure/nvidia-device-plugin/base/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         nvidia.com/gpu: "true"
       containers:
         - name: nvidia-device-plugin
-          image: nvcr.io/nvidia/k8s-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
           env:
             - name: FAIL_ON_INIT_ERROR
               value: "false"

--- a/infrastructure/nvidia-device-plugin/base/kustomization.yaml
+++ b/infrastructure/nvidia-device-plugin/base/kustomization.yaml
@@ -7,6 +7,3 @@ resources:
 commonLabels:
   app.kubernetes.io/name: nvidia-device-plugin
   app.kubernetes.io/part-of: gpu-infrastructure
-images:
-  - name: nvcr.io/nvidia/k8s-device-plugin
-    newTag: v0.17.0


### PR DESCRIPTION
Closes BOW-384.

## Problem
Same Renovate blind spot as immich (#316): both GPU device plugins had **untagged** daemonset `image:` lines with versions hidden in kustomize `images: newTag:` blocks that Renovate's kubernetes manager doesn't read. Neither has ever been bumped by Renovate.

## Fix
Inline the tags, remove the `images:` blocks:
- `intel-gpu-plugin` daemonset → `image: intel/intel-gpu-plugin:0.31.0`
- `nvidia-device-plugin` daemonset → `image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0`

`infrastructure/.+\.yaml$` is already in Renovate's scan scope, so inlining alone makes them tracked (no packageRule needed — no `-cuda`-style quirk).

## Verification
- `kustomize build` renders **byte-identical images** for both → **no cluster change, zero pods roll on merge**.
- After merge, Renovate's next scan lists both as versioned deps.