### PR TITLE
fix: persist immich redis job queue with AOF and a PVC

### DIFF
--- a/apps/immich/base/redis-deployment.yaml
+++ b/apps/immich/base/redis-deployment.yaml
@@ -18,6 +18,10 @@ metadata:
   namespace: immich
 spec:
   replicas: 1
+  # Recreate: redis-pvc is ReadWriteOnce, so the old pod must release the
+  # volume before the new one can attach.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: redis
@@ -26,10 +30,22 @@ spec:
       labels:
         app: redis
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
         - name: redis
           image: redis:7-alpine
-          args: ["--save", ""]
+          # AOF persistence: the BullMQ job queue (immich_bull:*) lives only in
+          # redis. Without this, a restart silently drops every queued job while
+          # Postgres still marks the assets incomplete, and nothing re-queues them.
+          command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --appendfsync
+            - everysec
+            - --dir
+            - /data
           ports:
             - containerPort: 6379
           volumeMounts:
@@ -42,6 +58,19 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
       volumes:
         - name: redis-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: redis-pvc

--- a/apps/immich/overlay/korriban/storage.yaml
+++ b/apps/immich/overlay/korriban/storage.yaml
@@ -65,6 +65,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: redis-pvc
   namespace: immich
+  # Overlay-only resources don't inherit base/kustomization.yaml commonLabels,
+  # so set them explicitly.
+  labels:
+    app.kubernetes.io/name: immich
+    app.kubernetes.io/part-of: photo-management
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/immich/overlay/korriban/storage.yaml
+++ b/apps/immich/overlay/korriban/storage.yaml
@@ -57,3 +57,18 @@ spec:
   resources:
     requests:
       storage: 10Ti
+---
+# Redis AOF persistence for the immich BullMQ job queue.
+# Matches the n8n/redis and harbor/valkey convention (nfs-holocron-fast, 2Gi, RWO).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-holocron-fast
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Summary

immich's redis backs the BullMQ job queue (`immich_bull:*`), but persistence was disabled twice over:

```yaml
args: ["--save", ""]     # RDB snapshots off
volumes:
  - name: redis-data
    emptyDir: {}         # /data ephemeral anyway
```

Verified live before the change: `config get save` empty, `config get appendonly` = `no`, 115 days uptime.

Any redis restart (reschedule, drain, OOM, image bump) discarded every queued and in-flight job. Postgres still recorded the asset as incomplete (`asset_job_status.thumbnailAt IS NULL`), but nothing re-queues automatically — immich only redispatches on an explicit admin "Missing" run or on new asset arrival. Silent permanent gaps in thumbnails/ML/metadata.

Closes BOW-400.

## Changes

- `--save ""` replaced with `--appendonly yes --appendfsync everysec --dir /data`. Dropping the `--save` override also restores redis' default RDB save points, so both mechanisms are active.
- `/data` moved from `emptyDir` to a new `redis-pvc` (2Gi, RWO, `nfs-holocron-fast`).
- `strategy: Recreate` — required, since a RWO PVC plus the default RollingUpdate would deadlock (new pod can't attach until the old one releases).
- `fsGroup: 999` so the redis user owns `/data`.
- Liveness/readiness probes on `redis-cli ping`.

Storage class, size and access mode match the existing convention for `n8n/redis-pvc` and `harbor/harbor-valkey` (both `nfs-holocron-fast`, 2Gi, RWO). immich's redis was the only one in the cluster on `emptyDir`.

## Verification

- `kubectl kustomize clusters/korriban/apps` builds clean (11000 lines).
- Rendered output confirmed: `strategy.type: Recreate`, AOF command flags, `claimName: redis-pvc`, PVC at `nfs-holocron-fast`/2Gi/RWO in namespace `immich`.
- Image left at `redis:7-alpine` — no version bump in this PR.

## Note before merging

Flux applying this **will restart redis and reset the queue**, because `Recreate` tears down the old pod and the emptyDir contents are discarded on the switch to the PVC. The queues are currently empty (0 waiting / 0 active / 0 failed / 0 delayed, none paused), so now is a safe window. Worth re-checking queue depth immediately before merge if any large import or job run has been started since.