### PR TITLE
fix: run immich redis as non-root and gate liveness behind AOF recovery

### DIFF
--- a/apps/immich/base/redis-deployment.yaml
+++ b/apps/immich/base/redis-deployment.yaml
@@ -30,10 +30,7 @@ spec:
       labels:
         app: redis
     spec:
-      # Run as the redis uid explicitly. `command:` below bypasses the image
-      # entrypoint (which would normally drop root -> redis), so without this the
-      # network-facing redis process would run as root. The export squashes to
-      # 1024:users with mode 0777, so uid 999 writes fine — same as harbor/valkey.
+      # `command:` bypasses the entrypoint's root -> redis drop, so set the uid here.
       securityContext:
         fsGroup: 999
         runAsUser: 999
@@ -49,17 +46,22 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
-          # AOF persistence: the BullMQ job queue (immich_bull:*) lives only in
-          # redis. Without this, a restart silently drops every queued job while
-          # Postgres still marks the assets incomplete, and nothing re-queues them.
+          # AOF persists the BullMQ queue; nothing re-queues jobs if it's lost.
+          # umask 0077 because `command:` bypasses the entrypoint that sets it.
+          # --save '' keeps RDB off: save points enable stop-writes-on-bgsave-error,
+          # which freezes all writes after one failed BGSAVE.
           command:
-            - redis-server
-            - --appendonly
-            - "yes"
-            - --appendfsync
-            - everysec
-            - --dir
-            - /data
+            - /bin/sh
+            - -c
+            - >-
+              umask 0077;
+              exec redis-server
+              --appendonly yes
+              --appendfsync everysec
+              --save ''
+              --maxmemory 256mb
+              --maxmemory-policy noeviction
+              --dir /data
           ports:
             - containerPort: 6379
           volumeMounts:
@@ -72,11 +74,8 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
-          # Redis answers PING with a -LOADING error until the AOF is fully
-          # replayed, so a bare liveness probe would kill it mid-recovery and
-          # crash-loop forever once the AOF outgrows ~50s of load time. The
-          # startupProbe gates liveness/readiness until recovery completes,
-          # allowing up to 10 minutes.
+          # -e makes redis-cli exit non-zero on the -LOADING error during AOF
+          # replay; without it these probes pass instantly and gate nothing.
           startupProbe:
             exec:
               command: ["redis-cli", "-e", "ping"]

--- a/apps/immich/base/redis-deployment.yaml
+++ b/apps/immich/base/redis-deployment.yaml
@@ -30,11 +30,25 @@ spec:
       labels:
         app: redis
     spec:
+      # Run as the redis uid explicitly. `command:` below bypasses the image
+      # entrypoint (which would normally drop root -> redis), so without this the
+      # network-facing redis process would run as root. The export squashes to
+      # 1024:users with mode 0777, so uid 999 writes fine — same as harbor/valkey.
       securityContext:
         fsGroup: 999
+        runAsUser: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: redis
           image: redis:7-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           # AOF persistence: the BullMQ job queue (immich_bull:*) lives only in
           # redis. Without this, a restart silently drops every queued job while
           # Postgres still marks the assets incomplete, and nothing re-queues them.
@@ -58,16 +72,25 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          # Redis answers PING with a -LOADING error until the AOF is fully
+          # replayed, so a bare liveness probe would kill it mid-recovery and
+          # crash-loop forever once the AOF outgrows ~50s of load time. The
+          # startupProbe gates liveness/readiness until recovery completes,
+          # allowing up to 10 minutes.
+          startupProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             exec:
               command: ["redis-cli", "ping"]
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
           readinessProbe:
             exec:
               command: ["redis-cli", "ping"]
-            initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3
       volumes:

--- a/apps/immich/base/redis-deployment.yaml
+++ b/apps/immich/base/redis-deployment.yaml
@@ -79,18 +79,18 @@ spec:
           # allowing up to 10 minutes.
           startupProbe:
             exec:
-              command: ["redis-cli", "ping"]
+              command: ["redis-cli", "-e", "ping"]
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 60
           livenessProbe:
             exec:
-              command: ["redis-cli", "ping"]
+              command: ["redis-cli", "-e", "ping"]
             periodSeconds: 10
             timeoutSeconds: 5
           readinessProbe:
             exec:
-              command: ["redis-cli", "ping"]
+              command: ["redis-cli", "-e", "ping"]
             periodSeconds: 5
             timeoutSeconds: 3
       volumes:

--- a/apps/immich/base/redis-deployment.yaml
+++ b/apps/immich/base/redis-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           # umask 0077 because `command:` bypasses the entrypoint that sets it.
           # --save '' keeps RDB off: save points enable stop-writes-on-bgsave-error,
           # which freezes all writes after one failed BGSAVE.
+          # maxmemory 256mb = half the 512Mi limit, leaving room for the AOF-rewrite
+          # fork; noeviction rejects writes rather than silently dropping queued jobs.
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## Summary

Follow-up to #325. Addresses the two **P2** findings Codex raised on that PR, which were reported after #325 had already been merged, so they never made it in.

Closes the remaining BOW-400 hardening.

## P2-1 — Redis was running as root

`command:` bypasses the official image's `docker-entrypoint.sh`, which is what normally drops UID 0 → `redis` before starting the server. #325 set only `fsGroup`, so the network-facing redis process ran as **root**.

The obvious fix — switch back to `args:` — is not available here: the entrypoint runs `find . \! -user redis -exec chown redis '{}' +` under `set -e`, and root chown fails on this squashed NFS export (`Operation not permitted`, verified against a live pod on the same storage class). That path crash-loops.

So `command:` stays and the UID is set explicitly instead:

```yaml
securityContext:
  fsGroup: 999
  runAsUser: 999
  runAsGroup: 999
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
```
plus `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]` on the container.

This is exactly the posture `harbor/harbor-valkey` already runs with on this same storage class. Verified it can write there as uid 999:

```
$ id; touch /data/.wtest
uid=999(valkey) gid=999(ping)
WRITE OK as 999
-rw-r--r-- 1 1024 users 0 /data/.wtest
```

The export squashes to `1024:users` mode 0777, so on-disk ownership is identical either way — the entrypoint's chown/setpriv would not have changed the outcome, only who the process runs as.

**Bonus:** this also clears the PodSecurity `restricted` warnings the immich namespace was emitting for this workload. `kubectl apply --dry-run=server` now returns clean, no warning.

## P2-2 — Liveness probe could kill Redis mid-recovery

Redis answers PING with a `-LOADING` error until the AOF is fully replayed. With #325's probes (`initialDelaySeconds: 30`, `periodSeconds: 10`, default `failureThreshold: 3`) an AOF taking more than ~50s to load — plausible as this NFS-backed queue grows — trips liveness and restarts Redis before recovery finishes. That is a permanent crash loop, and it only manifests once the volume has real data in it, so it would not have shown up on first deploy.

Added a `startupProbe` (`periodSeconds: 10`, `failureThreshold: 60`) so liveness/readiness don't begin until recovery completes — up to 10 minutes of headroom.

## Verification

- `kubectl kustomize clusters/korriban/apps` builds clean.
- Rendered output confirmed to carry all of `runAsUser/runAsGroup/runAsNonRoot/seccompProfile`, the container hardening, and `startupProbe.failureThreshold: 60`.
- `kubectl apply --dry-run=server` on the rendered Deployment: `configured`, **no PodSecurity warning**.

## Rollout impact (corrected)

#325 has already reconciled — redis is **currently running as root on the PVC** (verified live: `uid=0`, AOF active). Merging #326 is therefore a **second `Recreate` roll**, not a hardened first-start. Impact: a brief redis-unavailable gap during pod replacement + AOF replay (startupProbe budget 600s). The queue is persisted on the PVC, so **no job loss** — immich enqueues just pause during the gap. Schedule when no large import is in flight.

## Post-merge verification

1. `kubectl -n immich exec deploy/redis -- id` → `uid=999`
2. `redis-cli config get appendonly` → `yes`; `config get save` → empty; `config get maxmemory` → `268435456`
3. Pod reaches Ready only after AOF replay, **0** crash-loop restarts (startupProbe gating works)
4. `redis-cli --scan --pattern 'immich_bull:*'` non-empty after the roll (queue survived)
5. `kubectl apply` (Flux) emits **no** PodSecurity `restricted` warning for redis
