### PR TITLE
feat(immich): upgrade to v3.0.3

### DIFF
--- a/apps/immich/base/immich-ml-deployment.yaml
+++ b/apps/immich/base/immich-ml-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         nvidia.com/gpu: "true"
       containers:
         - name: immich-ml
-          image: ghcr.io/immich-app/immich-machine-learning:v2.4.1-cuda
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.3-cuda
           ports:
             - containerPort: 3003
           env:

--- a/apps/immich/base/immich-ml-deployment.yaml
+++ b/apps/immich/base/immich-ml-deployment.yaml
@@ -52,6 +52,12 @@ spec:
               cpu: "4"
               memory: 8Gi
               nvidia.com/gpu: "1"
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: 3003
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /ping

--- a/apps/immich/base/immich-server-deployment.yaml
+++ b/apps/immich/base/immich-server-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         nvidia.com/gpu: "true"
       containers:
         - name: immich-server
-          image: ghcr.io/immich-app/immich-server:v2.4.1
+          image: ghcr.io/immich-app/immich-server:v3.0.3
           ports:
             - containerPort: 2283
           envFrom:

--- a/apps/immich/base/immich-server-deployment.yaml
+++ b/apps/immich/base/immich-server-deployment.yaml
@@ -66,6 +66,13 @@ spec:
               cpu: "8"
               memory: 8Gi
               nvidia.com/gpu: "1"
+          # Gate liveness until first-boot DB migration completes (v3 migrates before binding :2283).
+          startupProbe:
+            httpGet:
+              path: /api/server/ping
+              port: 2283
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /api/server/ping

--- a/apps/renovate/base/helmrelease.yaml
+++ b/apps/renovate/base/helmrelease.yaml
@@ -99,12 +99,9 @@ spec:
           secretKeyRef:
             name: renovate-secrets
             key: RENOVATE_TOKEN
-      # Authenticate ghcr container-tag lookups with the same token.
-      # Anonymous ghcr requests are rate-limited (429), which silently blocked
-      # immich update detection. $(RENOVATE_TOKEN) is expanded by the kubelet at
-      # runtime from the secret above, so the token never lands in git.
+      # Auth ghcr lookups (anon 429s block immich detection); ghcr needs Basic, not Bearer.
       - name: RENOVATE_HOST_RULES
-        value: '[{"matchHost":"ghcr.io","hostType":"docker","token":"$(RENOVATE_TOKEN)"}]'
+        value: '[{"matchHost":"ghcr.io","hostType":"docker","username":"cbown75","password":"$(RENOVATE_TOKEN)"}]'
 
     # Resource requests and limits
     resources:

--- a/apps/renovate/base/helmrelease.yaml
+++ b/apps/renovate/base/helmrelease.yaml
@@ -99,6 +99,12 @@ spec:
           secretKeyRef:
             name: renovate-secrets
             key: RENOVATE_TOKEN
+      # Authenticate ghcr container-tag lookups with the same token.
+      # Anonymous ghcr requests are rate-limited (429), which silently blocked
+      # immich update detection. $(RENOVATE_TOKEN) is expanded by the kubelet at
+      # runtime from the secret above, so the token never lands in git.
+      - name: RENOVATE_HOST_RULES
+        value: '[{"matchHost":"ghcr.io","hostType":"docker","token":"$(RENOVATE_TOKEN)"}]'
 
     # Resource requests and limits
     resources:


### PR DESCRIPTION
## Summary

Upgrades immich from **v2.4.1 → v3.0.3** (server + machine-learning). This is the fix for mobile backup being stuck: the phone's immich app auto-updated into the v3.x line ~2026-07-14, the server stayed on v2.4.1, and immich requires the app and server to be version-compatible. Last successful upload was 2026-07-12; the app has been unable to back up since.

## Why the server was frozen

Renovate has been silently failing to propose immich updates. Its logs show `statusCode: 429` from ghcr — anonymous rate-limiting on the machine-learning repo's 1000+ tag enumeration → `no-result`. Because `immich-server` and `immich-machine-learning` are grouped (lockstep versioning, BOW-383), the failed ML lookup blocked the server bump too. So immich sat on v2.4.1 while v3.0.0–v3.0.3 shipped.

**Renovate ghcr-auth fix is included** (`apps/renovate/base/helmrelease.yaml`): a `RENOVATE_HOST_RULES` entry authenticates ghcr via Basic auth (username + password) reusing the existing `RENOVATE_TOKEN` — no new secret. ghcr requires Basic, not Bearer (verified: `token` rule 403s, username/password 200s). Validated post-deploy by a manual Renovate run (log no longer shows 429/no-result for immich-machine-learning).

## Safety — this migration is irreversible

immich v3 runs schema migrations automatically on first boot; **v2.4.1 cannot run against the migrated DB**. Safety net established before merge:

- **Verified restorable backup.** `immich-postgres-20260724-184036.sql.gz` (fresh, pre-migration) + daily 158M dumps, 14-day retention. Gzip-verified valid `pg_dumpall` — 59 tables, self-contained `DROP DATABASE`/role recreation, so restoring it is a complete rollback to pre-migration state.
- **VectorChord prerequisite met.** v3 drops pgvecto.rs and requires VectorChord; the DB already has `vchord 0.4.3` (migrated in #296/#297). The one thing that makes v3 destructive does not apply here.
- **No v3-removed env vars in use.** The removed ML preload / ping-timeout / OAuth vars are not set; only `MACHINE_LEARNING_CACHE_FOLDER` is present. No config changes needed.
- **Tags confirmed to exist** in ghcr (`v3.0.3`, `v3.0.3-cuda`).

## Changes

- `apps/immich/base/immich-server-deployment.yaml`: `v2.4.1` → `v3.0.3`
- `apps/immich/base/immich-ml-deployment.yaml`: `v2.4.1-cuda` → `v3.0.3-cuda`
- `apps/renovate/base/helmrelease.yaml`: add ghcr Basic-auth hostRule (reuses existing RENOVATE_TOKEN)

## Verification (post-merge, post-reconcile)

1. Both pods Running on v3.0.3; immich-server logs show schema migrations completed, no errors.
2. Asset count intact: `SELECT count(*) FROM asset WHERE "deletedAt" IS NULL;` == **25464**.
3. Web UI loads and browses.
4. **Phone backup starts moving** — the actual acceptance test.

## Rollback

If v3 fails to start or data looks wrong: restore `immich-postgres-20260724-184036.sql.gz` (drops+recreates the immich DB to pre-migration state), revert the two image tags. Nothing can upload today, so the effective data-loss window is zero.

## Migration prerequisite — VERIFIED (not just asserted)

immich v3 hard-errors if the vector backend resolves to pgvecto.rs. Confirmed on the live DB it cannot:

```
extname | extversion        vectors (pgvecto.rs) present: 0
--------+-----------        smart_search.embedding: vector(512)
vchord  | 0.4.3
vector  | 0.8.0
```

VectorChord present, pgvecto.rs absent, embeddings already in `vector(512)` form — the #296/#297 data migration is complete. Eliminates the only realistic v3 boot-failure path.

## Added since review: startupProbe (code-review-327 P2)

immich runs its v3 schema migration synchronously *before* binding `:2283`, so `/api/server/ping` is connection-refused during migration. The prior liveness budget (~120s) could kill the pod mid-migration and crashloop under `Recreate` with no fallback. Added `startupProbe` (600s budget) to both immich-server and immich-ml so liveness/readiness are gated until first boot completes.
