### PR TITLE
fix(flux): raise media-apps health-check timeout to 12m

### DIFF
--- a/clusters/korriban/flux-system/kustomization-media-apps.yaml
+++ b/clusters/korriban/flux-system/kustomization-media-apps.yaml
@@ -14,5 +14,5 @@ spec:
   path: ./clusters/korriban/apps
   prune: true
   wait: true
-  timeout: 5m0s
+  timeout: 12m0s
   retryInterval: 2m0s


### PR DESCRIPTION
## Summary

`media-apps` runs `wait: true` with a **5m0s** timeout over ~20 media apps. During BOW-405, Flux recorded:

```
lastReconciledStatus:   HealthCheckFailed
lastReconciledDuration: 5m1.023767729s
revision:               main@sha1:dd47c26
```

A one-time alembic schema migration made bazarr take **8m59s** to become Ready, so the shared health check expired and the entire Kustomization went NotReady — degrading reconciliation status for all 20 apps.

## Why 12m and not a round number

Derived from the pod-side ceiling, which is the real constraint:

| Constraint | Value |
|---|---|
| bazarr `progressDeadlineSeconds` | 600s |
| bazarr startupProbe budget | 60 × 10s = 600s |
| Measured migration boot | 8m59s (539s) |
| Measured steady-state boot | 25s |
| Health check when healthy | 1.8s |

No pod can become healthy after ~600s — the kubelet kills it or the Deployment flips to `ProgressDeadlineExceeded`. **720s clears that ceiling with 120s of margin** for apply, scheduling and image pull.

Going higher buys nothing (the pod is already dead) and further delays failure detection for the other 19 apps. My first draft used 15m; review correctly pointed out the 10–15m band is unreachable.

This budget is only ever consumed during a schema migration — steady state is 25s.

## Correction to the original ticket

BOW-408 cited the sibling `apps` Kustomization's `timeout: 10m` as precedent. That is **not** a comparable — `apps` has no `wait: true`, so its timeout covers only build and apply, never health checks. `infrastructure` (10m, `wait: true`) is the only true comparable, and this puts media-apps 20% above it, justified by the measured 600s pod ceiling.

## Found while reviewing — filed separately

**The Flux alerts are dead.** `FluxReconciliationFailure` queries `gotk_reconcile_condition` and `FluxResourceSuspended` queries `gotk_suspend_status`. Neither metric exists in Flux v2.8.6. Verified against the controller directly:

```
$ kubectl -n flux-system exec deploy/kustomize-controller -- \
    wget -qO- http://localhost:8080/metrics | grep -c gotk_reconcile_condition
0
```

Only `gotk_reconcile_duration_seconds` and two token-cache metrics are exported. **Both alerts have been silently non-functional** — which is why `media-apps` could sit `HealthCheckFailed` for 26 days unnoticed. That is the more important defect and is tracked on its own ticket; this PR does not attempt it.

Also deferred: `media-apps` has no `dependsOn: media-storage`, and `media-storage` lacks `wait: true`, so unbound PVCs can stall the health check for the full timeout. And the divergent duplicate of this object in `kubernetes-private/clusters/korriban/flux-system/apps-kustomization.yaml` (still `5m0s`, no `dependsOn`) should be deleted.

## Verification

- YAML valid, format consistent with sibling fields (`interval: 10m0s`, `retryInterval: 2m0s`).
- `kubectl kustomize clusters/korriban/flux-system` renders the object correctly.
- Post-merge: confirm `kubectl -n flux-system get kustomization media-apps` shows `timeout=12m0s` and stays Ready.

Closes BOW-408