### PR TITLE
feat(monitoring): add PodNotReadyProlonged alert for Running-but-not-Ready pods (BOW-406)

### DIFF
--- a/apps/prometheus/base/helmrelease.yaml
+++ b/apps/prometheus/base/helmrelease.yaml
@@ -184,8 +184,8 @@ spec:
                 annotations:
                   summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} not ready"
                   description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes."
-              # Pod Running but never Ready — the BOW-405 gap: PodNotReady only
-              # matches phase=Pending|Unknown, so a Running pod with a permanently
+              # Pod Running but never Ready — the gap BOW-405 exposed: PodNotReady
+              # only matches phase=Pending|Unknown, so a Running pod with a permanently
               # failing readiness probe is invisible. Scoped to phase=Running so
               # completed CronJob pods (also ready=false) do not false-fire.
               - alert: PodNotReadyProlonged

--- a/apps/prometheus/base/helmrelease.yaml
+++ b/apps/prometheus/base/helmrelease.yaml
@@ -184,6 +184,18 @@ spec:
                 annotations:
                   summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} not ready"
                   description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes."
+              # Pod Running but never Ready — the BOW-405 gap: PodNotReady only
+              # matches phase=Pending|Unknown, so a Running pod with a permanently
+              # failing readiness probe is invisible. Scoped to phase=Running so
+              # completed CronJob pods (also ready=false) do not false-fire.
+              - alert: PodNotReadyProlonged
+                expr: kube_pod_status_ready{condition="false"} == 1 and on (namespace, pod) kube_pod_status_phase{phase="Running"} == 1
+                for: 15m
+                labels:
+                  severity: warning
+                annotations:
+                  summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} is Running but not Ready"
+                  description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been Running but not Ready for longer than 15 minutes (failing readiness probe)."
               # Deployment replica mismatch
               - alert: DeploymentReplicasMismatch
                 expr: (kube_deployment_spec_replicas - kube_deployment_status_replicas_ready) > 0


### PR DESCRIPTION
## Summary
Adds a `PodNotReadyProlonged` alert closing the observability gap that let the BOW-405 bazarr outage hide for 26 days — a pod with `phase=Running` but a permanently failing readiness probe was invisible to every existing rule.

- New rule in the `kubernetes.rules` group of `apps/prometheus/base/helmrelease.yaml`:
  `kube_pod_status_ready{condition="false"} == 1 and on (namespace, pod) kube_pod_status_phase{phase="Running"} == 1`, `for: 15m`, `severity: warning`.
- `phase="Running"` scoping is deliberate — it excludes completed Job/CronJob pods (which also report `ready=false`) so they don't false-fire.

## Why the rule lives here, not where BOW-406 proposed
The ticket proposed `apps/alertmanager/base/prometheus-rules.yaml` (a `PrometheusRule` CR). That CR is **never evaluated** — this cluster has no prometheus-operator controller (only its CRDs), established and fixed in BOW-414. The live rule engine reads `serverFiles.alerting_rules.yml` in the Prometheus HelmRelease, so the rule was added there. Placing it in the CR would have reproduced the exact invisible-monitoring failure this ticket exists to fix.

## Acceptance criteria
- **AC#1 (Running-but-not-Ready fires):** implemented by this alert.
- **AC#2 (restarting >5×/hr, exit code 0, fires):** already satisfied by the existing `PodCrashLooping` (`increase(kube_pod_container_status_restarts_total[1h]) > 3`) — a restart-count rule independent of CrashLoopBackOff/exit-code (rewritten in BOW-414). A second restart-rate rule would only double-fire on the same symptom, so it was intentionally not added.
- **AC#3 (verified against a wedged pod):** post-merge — see test plan.

## Design notes (from pre-PR review)
- The alert intentionally overlaps `DeploymentReplicasMismatch`/`StatefulSetReplicasMismatch` for a pod behind a workload. This is complementary, not noise: the pod-level alert says *which* pod and *why* (readiness), the workload-level says the workload is degraded. Not suppressed — hiding the pod detail during a workload failure would drop the most actionable signal.

## Test plan
- [ ] PromQL validated against live Prometheus (done pre-merge — already matched a real Running-but-not-Ready pod, `pyroscope-0`)
- [ ] After merge + Flux reconcile: confirm `PodNotReadyProlonged` appears in `/api/v1/rules`
- [ ] Confirm it fires against `pyroscope-0` (a real 97-day Running-but-not-Ready pod — no canary needed) and reaches Alertmanager `/api/v2/alerts`

## Follow-ups (out of scope, to be ticketed)
- `KubeStateMetricsDown` `absent()` backstop — if kube-state-metrics stops exporting, every KSM-based pod alert silently goes inert (mirrors the repo's existing `FluxMetricsMissing`/`AlertmanagerMetricsMissing` pattern).
- Bound the per-pod fan-out on the Alertmanager `application` route so a mass-readiness outage can't flood `#home-applications`.

BOW-406