### PR TITLE
fix: resolve pyroscope and oncall-celery chronic crash loops

### DIFF
--- a/apps/oncall/base/helmrelease.yaml
+++ b/apps/oncall/base/helmrelease.yaml
@@ -103,6 +103,11 @@ spec:
         registry: docker.io
         repository: rabbitmq
         tag: "4.3-management"
+      # RabbitMQ 4.x disables transient_nonexcl_queues by default. grafana-oncall's
+      # celery worker declares a transient non-exclusive queue, so without this the
+      # broker throws internal_error and closes every connection, crash-looping celery.
+      extraConfiguration: |
+        deprecated_features.permit.transient_nonexcl_queues = true
       auth:
         username: user
         existingPasswordSecret: oncall-rabbitmq

--- a/apps/oncall/base/helmrelease.yaml
+++ b/apps/oncall/base/helmrelease.yaml
@@ -106,8 +106,18 @@ spec:
       # RabbitMQ 4.x disables transient_nonexcl_queues by default. grafana-oncall's
       # celery worker declares a transient non-exclusive queue, so without this the
       # broker throws internal_error and closes every connection, crash-looping celery.
-      extraConfiguration: |
-        deprecated_features.permit.transient_nonexcl_queues = true
+      # This deployment runs the official rabbitmq image, which reads
+      # /etc/rabbitmq/conf.d/*.conf and ignores Bitnami's extraConfiguration path, so
+      # the permit is delivered as a conf.d drop-in via the ConfigMap below.
+      extraVolumes:
+        - name: extra-config
+          configMap:
+            name: oncall-rabbitmq-extra-config
+      extraVolumeMounts:
+        - name: extra-config
+          mountPath: /etc/rabbitmq/conf.d/20-deprecated-features.conf
+          subPath: 20-deprecated-features.conf
+          readOnly: true
       auth:
         username: user
         existingPasswordSecret: oncall-rabbitmq

--- a/apps/oncall/base/kustomization.yaml
+++ b/apps/oncall/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - helmrepository.yaml
   - namespace.yaml
+  - rabbitmq-extra-config.yaml
   - helmrelease.yaml
 commonLabels:
   app.kubernetes.io/name: oncall

--- a/apps/oncall/base/rabbitmq-extra-config.yaml
+++ b/apps/oncall/base/rabbitmq-extra-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oncall-rabbitmq-extra-config
+  namespace: oncall
+data:
+  # Mounted at /etc/rabbitmq/conf.d/20-deprecated-features.conf. The official
+  # rabbitmq image reads /etc/rabbitmq/conf.d/*.conf; it does NOT read Bitnami's
+  # extraConfiguration path, so the permit has to be delivered as a conf.d drop-in.
+  20-deprecated-features.conf: |
+    deprecated_features.permit.transient_nonexcl_queues = true

--- a/apps/pyroscope/base/configmap.yaml
+++ b/apps/pyroscope/base/configmap.yaml
@@ -12,24 +12,33 @@ data:
       http_listen_port: 4040
       log_level: info
 
-    # Storage configuration
+    # Storage configuration. /data is the mounted PVC; the filesystem object-store
+    # "bucket" gets its own subdir so it is not polluted by the node-local working
+    # dirs below (the objstore client enumerates its root as a flat bucket).
     storage:
       backend: filesystem
       filesystem:
-        dir: /data
+        dir: /data/blocks
 
-    # Pyroscope v2 writable data paths. The v2 raft metastore and store-gateway
-    # default to relative ./data/... under the working dir, which is the read-only
-    # container rootfs (runAsNonRoot). Point them at the /data PVC or the metastore
-    # boltdb fails to open with "read-only file system".
+    # All node-local writable paths must live on the /data PVC. Pyroscope's working
+    # directory is not writable to uid 10001, so any component defaulting to a
+    # relative ./data* path fails with "read-only file system". This covers the v2
+    # metastore + store-gateway and, under the default v1-v2-dual architecture, the
+    # v1 pyroscopedb + compactor dirs.
     metastore:
-      data_dir: /data/metastore/data
+      data_dir: /data/v2/metastore/data
       raft:
-        dir: /data/metastore/raft
+        dir: /data/v2/metastore/raft
 
     store_gateway:
       bucket_store:
         sync_dir: /data/pyroscope-sync
+
+    pyroscopedb:
+      data_path: /data/pyroscopedb
+
+    compactor:
+      data_dir: /data/compactor
 
     # Retention settings
     limits:

--- a/apps/pyroscope/base/configmap.yaml
+++ b/apps/pyroscope/base/configmap.yaml
@@ -18,6 +18,19 @@ data:
       filesystem:
         dir: /data
 
+    # Pyroscope v2 writable data paths. The v2 raft metastore and store-gateway
+    # default to relative ./data/... under the working dir, which is the read-only
+    # container rootfs (runAsNonRoot). Point them at the /data PVC or the metastore
+    # boltdb fails to open with "read-only file system".
+    metastore:
+      data_dir: /data/metastore/data
+      raft:
+        dir: /data/metastore/raft
+
+    store_gateway:
+      bucket_store:
+        sync_dir: /data/pyroscope-sync
+
     # Retention settings
     limits:
       max_query_lookback: 720h  # 30 days


### PR DESCRIPTION
## Summary
Fixes two chronic crash loops surfaced during the cluster health review after the coruscant node outage. Both were caused by a Renovate image bump that left config behind.

**pyroscope-0** (`monitoring`) — CrashLoopBackOff, 30,652 restarts / 97d. The bump to `grafana/pyroscope:2.0.x` (v2 architecture) left the raft metastore + other components writing to relative `./data*` paths on the non-writable working dir (uid 10001), so the metastore boltdb failed with `read-only file system`.
- `storage.filesystem.dir: /data/blocks` — object store gets its own bucket subdir so node-local dirs aren't enumerated as bucket objects
- `metastore.data_dir`, `metastore.raft.dir` → `/data/v2/metastore/*`
- `store_gateway.bucket_store.sync_dir: /data/pyroscope-sync`
- `pyroscopedb.data_path: /data/pyroscopedb`, `compactor.data_dir: /data/compactor` (v1 dirs active under the default `v1-v2-dual` architecture)

**oncall-celery** (`oncall`) — `RestartFreqExceeded`. Broker is RabbitMQ 4.3, which disables `transient_nonexcl_queues` by default; grafana-oncall's celery declares one, so the broker rejected every `queue.declare` with `internal_error` and closed the connection. The permit must reach the broker, but this deployment runs the **official** rabbitmq image which reads only `/etc/rabbitmq/conf.d/*.conf` (verified via `rabbitmq-diagnostics status`) — not Bitnami's `extraConfiguration` path.
- New `oncall-rabbitmq-extra-config` ConfigMap, mounted (subPath, readOnly) at `/etc/rabbitmq/conf.d/20-deprecated-features.conf` via the chart's `extraVolumes`/`extraVolumeMounts`

## Review
4-reviewer pre-PR loop (plan/code/security/codex), 2 passes. Pass 1 caught: the rabbitmq permit was a no-op (wrong config path) and the pyroscope fix was incomplete (object-store nesting + unredirected v1 paths) — both fixed in pass 2. Pass 2: code-review merge=yes, plan=aligned, security clean; one codex claim (a separate `metastore.raft.snapshots_dir`) dismissed as no such option exists in the config schema.

## Test plan
- [ ] After Flux reconciles, `pyroscope-0` reaches `1/1 Ready` and `/ready` returns 200 (watch for any further relative-path `read-only file system` errors from a later `-target=all` module)
- [ ] `oncall-rabbitmq-0` shows `transient_nonexcl_queues` permitted (`rabbitmq-diagnostics list_deprecated_features` / `... environment`)
- [ ] `oncall-celery` stops looping (restart count stable, no `RestartFreqExceeded`)
- [ ] Both kustomizations build clean (already verified locally: `kubectl kustomize apps/{pyroscope,oncall}/overlay/korriban`)

## Not addressed (deferred, out of scope)
- RabbitMQ Mnesia on NFS (`nfs-holocron-general`) — pre-existing
- Renovate pin for the rabbitmq deprecated-feature (future-bump hardening)
- transient-queue message durability on broker restart (upstream grafana-oncall behavior)

BOW-572