### PR TITLE
fix(pyroscope): survive slow v2 startup with startupProbe + decoupled liveness (BOW-570)

### DIFF
--- a/apps/pyroscope/base/statefulset.yaml
+++ b/apps/pyroscope/base/statefulset.yaml
@@ -57,8 +57,10 @@ spec:
           # (~300s, ~2x the observed cold start, under PodNotReadyProlonged's 15m so a
           # genuinely wedged pod still alerts). liveness is a TCP check on the http port
           # (process up), NOT /ready — /ready reflects raft election + ring membership,
-          # so a post-startup election or ring flap must not restart a live pod;
-          # readiness (/ready) pulls it from Service endpoints instead.
+          # so a post-startup election or ring flap fails readiness (not liveness),
+          # preventing a restart loop rather than preserving traffic (single replica).
+          # Tradeoff: a hung-but-listening process is not auto-restarted; readiness drops
+          # it and PodNotReadyProlonged (15m) pages for a manual restart.
           startupProbe:
             httpGet:
               path: /ready

--- a/apps/pyroscope/base/statefulset.yaml
+++ b/apps/pyroscope/base/statefulset.yaml
@@ -50,20 +50,32 @@ spec:
             limits:
               cpu: 2000m
               memory: 4Gi
-          livenessProbe:
+          # v2 (-target=all) startup is slow: the metastore must win a raft
+          # election and the segment-writer must join its ring and serve /ready
+          # for 30s before the pod is ready — well past a 45s liveness delay,
+          # which SIGTERM'd it mid-startup into a crash loop (BOW-570). startupProbe
+          # gates liveness/readiness until the first successful /ready, and liveness
+          # tolerates ~2m of unreadiness after startup so a slow election never kills it.
+          startupProbe:
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: 45
             periodSeconds: 10
             timeoutSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
       volumes:
         - name: pyroscope-config
           configMap:

--- a/apps/pyroscope/base/statefulset.yaml
+++ b/apps/pyroscope/base/statefulset.yaml
@@ -50,19 +50,22 @@ spec:
             limits:
               cpu: 2000m
               memory: 4Gi
-          # v2 (-target=all) startup is slow: the metastore must win a raft
-          # election and the segment-writer must join its ring and serve /ready
-          # for 30s before the pod is ready — well past a 45s liveness delay,
-          # which SIGTERM'd it mid-startup into a crash loop (BOW-570). startupProbe
-          # gates liveness/readiness until the first successful /ready, and liveness
-          # tolerates ~2m of unreadiness after startup so a slow election never kills it.
+          # v2 (-target=all) startup is slow: the metastore wins a raft election and
+          # the segment-writer joins its ring and serves /ready for 30s before the pod
+          # is ready — the old 45s liveness delay SIGTERM'd it mid-startup into a crash
+          # loop (BOW-570). startupProbe gates readiness/liveness until the first /ready
+          # (~300s, ~2x the observed cold start, under PodNotReadyProlonged's 15m so a
+          # genuinely wedged pod still alerts). liveness is a TCP check on the http port
+          # (process up), NOT /ready — /ready reflects raft election + ring membership,
+          # so a post-startup election or ring flap must not restart a live pod;
+          # readiness (/ready) pulls it from Service endpoints instead.
           startupProbe:
             httpGet:
               path: /ready
               port: http
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /ready
@@ -70,12 +73,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
             periodSeconds: 20
             timeoutSeconds: 5
-            failureThreshold: 6
+            failureThreshold: 3
       volumes:
         - name: pyroscope-config
           configMap:


### PR DESCRIPTION
## Summary
Fixes pyroscope-0's chronic crashloop (Running-but-never-Ready, ~30k restarts / 97d). This is a **probe-only** change — the v2 config migration already landed in PR #338; the remaining blocker was the probe config killing v2 mid-startup.

## Root cause (verified from live logs)
The image was bumped v1→v2 (`grafana/pyroscope:2.0.3`, `-target=all`). v2 startup is slow: the metastore must win a raft election (~100s, worsened by 97 days of crash-accumulated raft state) and the segment-writer must join its ring and serve `/ready` for 30s before the pod is Ready. The old `livenessProbe` (httpGet `/ready`, `initialDelaySeconds: 45`, `failureThreshold: 3`) SIGTERM'd the pod ~65s in — *before* it could go Ready — every time. Each kill appended more raft state, slowing the next boot: a doom loop.

## Change
`apps/pyroscope/base/statefulset.yaml`:
- **`startupProbe`** (httpGet `/ready`, `failureThreshold: 30` ≈ 300s) gates readiness/liveness until v2 finishes starting. 300s is ~2× the observed dirty cold start and well under `PodNotReadyProlonged`'s 15m, so a genuinely wedged pod still alerts.
- **`livenessProbe` → `tcpSocket` on the http port** (process-up only), decoupled from `/ready`. `/ready` reflects raft/ring readiness — using it for liveness would restart a live-but-unready pod on any post-startup election or ring flap, recreating the crashloop. (Caught by all 4 pre-PR reviewers.)
- `readinessProbe` keeps httpGet `/ready`; its former `initialDelaySeconds: 30` is removed because a startupProbe already gates readiness until first success (dead config otherwise).

### Tradeoff (documented, intended)
`tcpSocket` liveness cannot detect a hung-but-*listening* process. That recovery is now operator-driven: readiness drops the pod from the Service and **`PodNotReadyProlonged` (15m) pages** for a manual restart. This alert is verified working against this exact pod (it fired end-to-end to Alertmanager during BOW-406). Reverting to `/ready` liveness would reintroduce the crashloop, so the tradeoff is deliberate.

## Required companion step (one-time manual PVC wipe — NOT in this diff)
The existing PVC holds 97 days of corrupt/bloated metastore raft state, which is what makes the election take ~100s. A GitOps manifest can't (and shouldn't) encode a one-time data wipe. **After this merges + Flux reconciles**, run — pinned to `admin@korriban`:
```
kubectl --context admin@korriban -n monitoring scale statefulset/pyroscope --replicas=0
# wait for pyroscope-0 to terminate
kubectl --context admin@korriban -n monitoring get pvc storage-pyroscope-0   # confirm the exact target
kubectl --context admin@korriban -n monitoring delete pvc storage-pyroscope-0
kubectl --context admin@korriban -n monitoring scale statefulset/pyroscope --replicas=1
```
No real data is lost (v2 never successfully wrote; the v1 format is incompatible anyway). Never use `--force`/`--grace-period=0` on the PVC.

## Test plan
- [ ] After merge + Flux + the PVC wipe: `pyroscope-0` reaches `1/1 Ready` and stays Ready
- [ ] `PodNotReadyProlonged` for pyroscope-0 clears
- [ ] `kubectl kustomize apps/pyroscope/overlay/korriban` builds clean (verified locally)

## Review
Pre-PR 4-reviewer adversarial loop, 2 passes. Pass 1 (unanimous): liveness must not reuse `/ready` + 600s startup window over-provisioned — both fixed in pass 2. Pass 2: plan=Aligned, code/codex/security clean of blockers; remaining items (hung-listening tradeoff, 300s-vs-data-growth) are documented Low/Info.

## Follow-ups (deferred)
- Monitor real startup duration as retention data grows; revisit the 300s window if dirty starts trend past ~200s.
- Renovate should not auto-apply pyroscope majors again without a config migration (this whole incident was a v1→v2 auto-bump).

BOW-570
